### PR TITLE
Changing variables substitution to Jinja-Way

### DIFF
--- a/tasks/install_ldap.yml
+++ b/tasks/install_ldap.yml
@@ -5,13 +5,15 @@
 
 - name: Install the openldap and required Packages for RedHat
   yum: name={{ item }} state=installed
-  with_items: openldap_server_pkgs
+  with_items: 
+      - "{{ openldap_server_pkgs }}"
   when: ansible_os_family == 'RedHat'
 
 
 - name: Install the openldap and required Packages for Ubuntu
   apt: name={{ item }} state=installed update_cache=yes
-  with_items: openldap_server_pkgs
+  with_items: 
+      - "{{ openldap_server_pkgs }}"
   environment: env
   when: ansible_os_family == 'Debian'
 


### PR DESCRIPTION
Your way of variable using failed in my case:
```
TASK [openldapServer : Install the openldap and required Packages for RedHat] ******************************************************************************************************************************
failed: [server.com] (item=[u'openldap_server_pkgs']) => {"changed": false, "failed": true, "item": ["openldap_server_pkgs"], "msg": "No package matching 'openldap_server_pkgs' found available, installed or updated", "rc": 126, "results": ["No package matching 'openldap_server_pkgs' found available, installed or updated"]}
```